### PR TITLE
debugging for tokenization and pretraining

### DIFF
--- a/stFormer/tokenization/median_estimator.py
+++ b/stFormer/tokenization/median_estimator.py
@@ -232,7 +232,7 @@ class MedianEstimator:
             for f, ds in self.datasets.items():
                 out_file = self.out_path / f'{f.stem}_tdigests.pickle'
                 with open(out_file, 'wb') as fp:
-                    pickle.dump(td_dict, fp)
+                    pickle.dump(ds, fp)
                 logger.info(f"Saved T-Digests to {out_file}")
 
     def write_medians(self):


### PR DESCRIPTION
Changed:
1. more pretraining training and configuration arguments available
2. set most train/config as a default unless otherwise overwritten
3. changed tokenization to be vector instead of row tokenization processed in batches (removes necessity for nested loop)
4. removed arguments for neighborhood cells ranked tokens, we append them to spot tokens anyways, so this is no longer needed
5. fixed bugs related to removing neighborhood cell ranked tokens